### PR TITLE
Livewire 3 compatibility

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -7,6 +7,8 @@ use RainLab\Livewire\Helpers\LivewireHelper;
 use RainLab\Livewire\Twig\LivewireTokenParser;
 use System\Classes\PluginBase;
 use Livewire\Livewire;
+use Route;
+use Url;
 
 /**
  * Plugin for Livewire integration
@@ -49,6 +51,11 @@ class Plugin extends PluginBase
 
         Config::set('livewire.class_namespace', \App\Livewire::class);
 
+        if (method_exists('\Livewire\LivewireManager', 'setScriptRoute')) {
+            Livewire::setScriptRoute(function ($handle) {
+                return Route::get(Url::asset('/livewire/livewire.js'), $handle);
+            });
+        }
     }
 
     /**

--- a/Plugin.php
+++ b/Plugin.php
@@ -95,6 +95,7 @@ class Plugin extends PluginBase
             'functions' => [
                 'livewireStyles' => [LivewireHelper::class, 'renderStyles'],
                 'livewireScripts' => [LivewireHelper::class, 'renderScripts'],
+                'livewireScriptConfig' => [LivewireHelper::class, 'scriptConfig'],
             ],
             'tokens' => [
                 new LivewireTokenParser

--- a/behaviors/LivewireComponent.php
+++ b/behaviors/LivewireComponent.php
@@ -15,6 +15,10 @@ class LivewireComponent extends ComponentBehavior
      */
     public function beforeDisplay()
     {
+        if (!config('livewire.inject_assets', true)) {
+            return;
+        }
+        
         if ($this->controller->vars['livewireInjected'] ?? false) {
             return;
         }
@@ -30,6 +34,6 @@ class LivewireComponent extends ComponentBehavior
      */
     public function renderLivewire($component, $params = [])
     {
-        return Livewire::mount($component, $params)->html();
+        return LivewireHelper::renderLivewire($component, $params);
     }
 }

--- a/behaviors/LivewireComponent.php
+++ b/behaviors/LivewireComponent.php
@@ -4,6 +4,7 @@ use Block;
 use Livewire\Livewire;
 use Cms\Classes\ComponentBehavior;
 use RainLab\Livewire\Helpers\LivewireHelper;
+use Config;
 
 /**
  * LivewireComponent
@@ -15,10 +16,14 @@ class LivewireComponent extends ComponentBehavior
      */
     public function beforeDisplay()
     {
-        if (!config('livewire.inject_assets', true)) {
-            return;
+        if ($this->component->property('injectAssets') !== null) {
+            Config::set('livewire.inject_assets', $this->component->property('injectAssets'));
         }
         
+        if (!Config::get('livewire.inject_assets', true)) {
+            return;
+        }
+
         if ($this->controller->vars['livewireInjected'] ?? false) {
             return;
         }

--- a/behaviors/LivewireController.php
+++ b/behaviors/LivewireController.php
@@ -15,6 +15,10 @@ class LivewireController extends ControllerBehavior
      */
     public function beforeDisplay()
     {
+        if (!config('livewire.inject_assets', true)) {
+            return;
+        }
+        
         if ($this->controller->vars['livewireInjected'] ?? false) {
             return;
         }
@@ -30,6 +34,6 @@ class LivewireController extends ControllerBehavior
      */
     public function makeLivewire($component, $params = [])
     {
-        return Livewire::mount($component, $params)->html();
+        return LivewireHelper::renderLivewire($component, $params);
     }
 }

--- a/components/Livewire.php
+++ b/components/Livewire.php
@@ -32,6 +32,11 @@ class Livewire extends ComponentBase
      */
     public function defineProperties()
     {
-        return [];
+        return [
+            'injectAssets' => [
+                'title' => 'Inject Livewire Assets',
+                'type' => 'checkbox',
+            ],
+        ];
     }
 }

--- a/helpers/LivewireHelper.php
+++ b/helpers/LivewireHelper.php
@@ -62,6 +62,14 @@ class LivewireHelper
     }
 
     /**
+     * scriptConfig
+     */
+    public static function scriptConfig($options = [])
+    {
+        return FrontendAssets::scriptConfig($options);
+    }
+
+    /**
      * renderLivewire
      */
     public static function renderLivewire($component, $params = [])

--- a/helpers/LivewireHelper.php
+++ b/helpers/LivewireHelper.php
@@ -2,6 +2,7 @@
 
 use Url;
 use Livewire\Livewire;
+use Livewire\Mechanisms\FrontendAssets\FrontendAssets;
 
 /**
  * LivewireHelper
@@ -24,7 +25,12 @@ class LivewireHelper
      */
     public static function renderStyles($options = [])
     {
-        return Livewire::styles($options);
+        if (method_exists('\Livewire\LivewireManager', 'styles')) {
+            // Livewire v2
+            return Livewire::styles($options);
+        }
+        // Livewire v3
+        return FrontendAssets::styles($options);
     }
 
     /**
@@ -32,13 +38,19 @@ class LivewireHelper
      */
     public static function renderScripts($options = [])
     {
-        $turboScript = Url::asset('plugins/rainlab/livewire/assets/js/livewire-turbo.js');
+        if (method_exists('\Livewire\LivewireManager', 'scripts')) {
+            // Livewire v2
+            if (!isset($options['asset_url'])) {
+                $options['asset_url'] = Url::asset('');
+            }
 
-        if (!isset($options['asset_url'])) {
-            $options['asset_url'] = Url::asset('');
+            $scriptStr = Livewire::scripts($options);
+        } else {
+            // Livewire v3
+            $scriptStr = FrontendAssets::scripts($options);
         }
 
-        $scriptStr = Livewire::scripts($options);
+        $turboScript = Url::asset('plugins/rainlab/livewire/assets/js/livewire-turbo.js');
 
         $scriptStr = str_replace('data-turbolinks-eval="false"', '', $scriptStr);
 
@@ -47,5 +59,18 @@ class LivewireHelper
         $scriptStr .= '<script src="' . $turboScript . '" data-turbo-eval="false"></script>';
 
         return $scriptStr;
+    }
+
+    /**
+     * renderLivewire
+     */
+    public static function renderLivewire($component, $params = [])
+    {
+        if (class_exists('\Livewire\LifecycleManager')) {
+            // Livewire v2
+            return Livewire::mount($component, $params)->html();
+        }
+        // Livewire v3
+        return Livewire::mount($component, $params);
     }
 }

--- a/twig/LivewireNode.php
+++ b/twig/LivewireNode.php
@@ -40,7 +40,7 @@ class LivewireNode extends TwigNode
         }
 
         $compiler
-            ->write("echo \Livewire\Livewire::mount(")
+            ->write("echo \RainLab\Livewire\Helpers\LivewireHelper::renderLivewire(")
             ->subcompile($this->getNode('nodes')->getNode(0))
         ;
 
@@ -52,7 +52,7 @@ class LivewireNode extends TwigNode
         }
 
         $compiler
-            ->write(")->html();\n")
+            ->write(");\n")
         ;
     }
 }


### PR DESCRIPTION
- Uses Livewire v3 FrontendAssets class to render the assets
- New renderLivewire helper to solve the ->html() issue
- Implements Livewire::setScriptRoute
- Respects livewire.inject_assets config